### PR TITLE
Update infra module versions in development.md

### DIFF
--- a/docs/infrastructure/development.md
+++ b/docs/infrastructure/development.md
@@ -32,12 +32,12 @@ provider "google" {
 }
 
 module "gnomad-mytest" {
-  source              = "github.com/broadinstitute/tgg-terraform-modules//gnomad-vpc?ref=gnomad-vpc-v0.0.1"
+  source              = "github.com/broadinstitute/tgg-terraform-modules//gnomad-vpc?ref=gnomad-vpc-v0.0.2"
   network_name_prefix = "gnomad-mytest
 }
 
 module "gnomad-test-infra" {
-  source                                = "github.com/broadinstitute/tgg-terraform-modules//gnomad-browser-infra?ref=gnomad-browser-infra-v0.0.3"
+  source                                = "github.com/broadinstitute/tgg-terraform-modules//gnomad-browser-infra?ref=gnomad-browser-infra-v0.0.4"
   infra_prefix                          = "gnomad-mytest"
   vpc_network_name                      = module.gnomad-mytest.gnomad_vpc_network_name
   vpc_subnet_name                       = "gnomad-mytest-gke"
@@ -89,7 +89,7 @@ provider "google" {
 }
 
 module "gnomad-mytest" {
-  source              = "github.com/broadinstitute/tgg-terraform-modules//gnomad-vpc?ref=gnomad-vpc-v0.0.1"
+  source              = "github.com/broadinstitute/tgg-terraform-modules//gnomad-vpc?ref=gnomad-vpc-v0.0.2"
   network_name_prefix = "gnomad-mytest
 }
 


### PR DESCRIPTION
Updates `development.md` very minorly (3 characters total) to reference newer versions of the terraform modules used, removing the reference to `gnomad-browser-infra` version `0.0.3` which has a known bug.